### PR TITLE
added support for alertmanager_mute_time_intervals

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -122,3 +122,25 @@ alertmanager_amtool_config_alertmanager_url: "{{ alertmanager_web_external_url }
 
 # Extended output of `amtool` commands, use '' for less verbosity
 alertmanager_amtool_config_output: 'extended'
+
+# Default values you can see here ->  https://prometheus.io/docs/alerting/latest/configuration/#mute_time_interval
+alertmanager_mute_time_intervals: []
+
+# alertmanager_route:
+#  receiver: team-X-pager
+#  routes:
+#    - matchers: [ '{severity!="critical",environment!="prod"}' ]
+#      receiver: team-X-mails
+#      mute_time_intervals: [out-of-business-hours]
+
+# mute_time_intervals:
+#   - name: out-of-business-hours
+#     time_intervals:
+#      # Mute on Saturdays and Sundays, all day.
+#      - weekdays: ['Saturday','Sunday']
+#      # Mute in the morning and in the evening, any day.
+#      - times:
+#        - start_time: '00:00'
+#          end_time: '08:00'
+#        - start_time: '18:00'
+#          end_time: '24:00'

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -34,19 +34,21 @@
     - name: "Set alertmanager version to {{ _latest_release.json.tag_name[1:] }}"
       set_fact:
         alertmanager_version: "{{ _latest_release.json.tag_name[1:] }}"
-        alertmanager_checksum_url: "https://github.com/prometheus/alertmanager/releases/download/v{{ alertmanager_version }}/sha256sums.txt"
   when:
     - alertmanager_version == "latest"
     - alertmanager_binary_local_dir | length == 0
 
+- name: "Generate checksum url with selected version"
+  set_fact: 
+    alertmanager_checksum_url: "https://github.com/prometheus/alertmanager/releases/download/v{{ _latest_release.json.tag_name[1:] }}/sha256sums.txt"
+
 - name: "Get checksum for {{ go_arch }} architecture"
   set_fact:
-    alertmanager_checksum: "{{ lookup('url', 'https://github.com/prometheus/alertmanager/releases/download/v' + alertmanager_version + '/sha256sums.txt', wantlist=True) | list \
-                              select('contains', 'linux-' + go_arch + '.tar.gz') | list | first).split(' ')[0] }}"
+    alertmanager_checksum: "{{ (lookup('url', alertmanager_checksum_url, wantlist=True) | list | select('contains', 'linux-' + go_arch + '.tar.gz') | list | first).split(' ')[0] }}"
   when:
     - alertmanager_binary_local_dir | length == 0
   ignore_errors: true
-  register: alertmanager_checksum_lookup
+  register: alertmanager_checksum_lookup 
 
 - name: Checksum lookup error message
   fail:

--- a/templates/alertmanager.yml.j2
+++ b/templates/alertmanager.yml.j2
@@ -54,3 +54,7 @@ inhibit_rules:
 {% endif %}
 route:
   {{ alertmanager_route | to_nice_yaml(indent=2) | indent(2, False) }}
+{% if alertmanager_mute_time_intervals | length %}
+mute_time_intervals:
+{{ alertmanager_mute_time_intervals | to_nice_yaml(indent=2)}}
+{% endif %}


### PR DESCRIPTION
+ added support for mute_time_intervals #146
+ fixed task `Generate checksum url with selected version` which was missing a starting parenthesis for the split
+ fixed bug with alertmanager_version not being populated with version number but stayed as `latest` causing checksum download to fail

```yaml
alertmanager_route:
 receiver: team-X-pager
 routes:
   - matchers: [ '{severity!="critical",environment!="prod"}' ]
     receiver: team-X-mails
     mute_time_intervals: [out-of-business-hours]

 alertmanager_mute_time_intervals:
  - name: out-of-business-hours
    time_intervals:
     # Mute on Saturdays and Sundays, all day.
     - weekdays: ['Saturday','Sunday']
     # Mute in the morning and in the evening, any day.
     - times:
       - start_time: '00:00'
         end_time: '08:00'
       - start_time: '18:00'
         end_time: '24:00' 
```